### PR TITLE
Use GitLab master branch as the source instead of manually uploaded .…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+repo/

--- a/io.gitlab.dev_nis.one-click-backup.yml
+++ b/io.gitlab.dev_nis.one-click-backup.yml
@@ -15,6 +15,8 @@ modules:
       sources:
       - type: git
         url: https://gitlab.com/dev-nis/nis-one-click-backup-qt.git
+        #tag: 1.2.2.1
+        branch: master
         #sha256: 69df0685ac7548d48379b5e02c9d70164d7837afb7c5c93fbbaa642cb8a13671
 
 

--- a/io.gitlab.dev_nis.one-click-backup.yml
+++ b/io.gitlab.dev_nis.one-click-backup.yml
@@ -13,8 +13,8 @@ modules:
     - name: NIS_One-Click-Backup_Qt
       buildsystem: cmake-ninja
       sources:
-      - type: archive
-        url: https://gitlab.com/dev-nis/nis-one-click-backup-qt/uploads/52b3341afaa35fbe92bd69995f971983/cmake.tar.gz
-        sha256: 69df0685ac7548d48379b5e02c9d70164d7837afb7c5c93fbbaa642cb8a13671
+      - type: git
+        url: https://gitlab.com/dev-nis/nis-one-click-backup-qt.git
+        #sha256: 69df0685ac7548d48379b5e02c9d70164d7837afb7c5c93fbbaa642cb8a13671
 
 

--- a/io.gitlab.dev_nis.one-click-backup.yml
+++ b/io.gitlab.dev_nis.one-click-backup.yml
@@ -15,8 +15,9 @@ modules:
       sources:
       - type: git
         url: https://gitlab.com/dev-nis/nis-one-click-backup-qt.git
-        #tag: 1.2.2.1
-        branch: master
+        #tag: '1.2.2.1'
+        commit: 9a1ca839ca511d55716ffc8898e5d9ec9449ef18
+        #branch: master
         #sha256: 69df0685ac7548d48379b5e02c9d70164d7837afb7c5c93fbbaa642cb8a13671
 
 


### PR DESCRIPTION
…tar.gz-file (possible due to recent CMakeLists changes)

(See [here](https://gitlab.com/dev-nis/nis-one-click-backup-qt/-/commit/9a1ca839ca511d55716ffc8898e5d9ec9449ef18) and [here](https://gitlab.com/dev-nis/nis-one-click-backup-qt/-/commit/736bcfd9f6ecd218904d7b57f9487376eb6bb365) for more details)