### PR TITLE
Update runtime to 6.10

### DIFF
--- a/io.gitlab.dev_nis.one-click-backup.yml
+++ b/io.gitlab.dev_nis.one-click-backup.yml
@@ -1,6 +1,6 @@
 id: io.gitlab.dev_nis.one-click-backup
 runtime: org.kde.Platform
-runtime-version: '6.6'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: NIS_One-Click-Backup_Qt
 finish-args:

--- a/io.gitlab.dev_nis.one-click-backup.yml
+++ b/io.gitlab.dev_nis.one-click-backup.yml
@@ -15,7 +15,6 @@ modules:
       sources:
       - type: git
         url: https://gitlab.com/dev-nis/nis-one-click-backup-qt.git
-        #tag: '1.2.2.1'
         commit: 9a1ca839ca511d55716ffc8898e5d9ec9449ef18
         #branch: master
         #sha256: 69df0685ac7548d48379b5e02c9d70164d7837afb7c5c93fbbaa642cb8a13671


### PR DESCRIPTION
Update runtime to 6.10

Fixes: https://github.com/flathub/io.gitlab.dev_nis.one-click-backup/issues/3